### PR TITLE
[FIX] Handle RPCError with bytes or unicode messages

### DIFF
--- a/odoorpc/error.py
+++ b/odoorpc/error.py
@@ -21,6 +21,7 @@
 """This module contains all exceptions raised by `OdooRPC` when an error
 occurred.
 """
+import sys
 
 
 class Error(Exception):
@@ -81,11 +82,24 @@ class RPCError(Error):
         True
     """
     def __init__(self, message, info=False):
+        # Ensure that the message is in unicode,
+        # to be compatible both with Python2 and 3
+        try:
+            message = message.decode('utf-8')
+        except (UnicodeEncodeError, AttributeError):
+            pass
         super(Error, self).__init__(message, info)
         self.info = info
 
     def __str__(self):
+        # args[0] should always be a unicode object (see '__init__(...)')
+        if sys.version_info[0] < 3 and self.args and self.args[0]:
+            return self.args[0].encode('utf-8')
         return self.args and self.args[0] or ''
+
+    def __unicode__(self):
+        # args[0] should always be a unicode object (see '__init__(...)')
+        return self.args and self.args[0] or u''
 
     def __repr__(self):
         return "%s(%s)" % (

--- a/odoorpc/tests/test_error.py
+++ b/odoorpc/tests/test_error.py
@@ -1,0 +1,25 @@
+# -*- coding: UTF-8 -*-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+
+from odoorpc.error import RPCError
+
+
+class TestError(unittest.TestCase):
+
+    def test_rpcerror_unicode_message(self):
+        message = u"é"
+        exc = RPCError(message)
+        str(exc)
+        if sys.version_info[0] < 3:
+            unicode(exc)
+
+    def test_rpcerror_str_message(self):
+        message = "é"
+        exc = RPCError(message)
+        str(exc)
+        if sys.version_info[0] < 3:
+            unicode(exc)


### PR DESCRIPTION
Exceptions raised by Odoo can uses bytes or unicode messages (Python 2, Odoo <= 10.0):
```python
raise UserError(u"é")

raise UserError("é")
```

This fix allows to print any `odoorpc.error.RPCError` exceptions correctly, whatever Odoo returns.
Fix #10 