### PR TITLE
[FIX] Migration from 'distutils' to 'setuptools', fixing the upload on https://pypi.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,30 @@ python:
   - "pypy"
 
 env:
-  - ORPC_TEST_VERSION=8.0"
-  - ORPC_TEST_VERSION=9.0"
-  - ORPC_TEST_VERSION=10.0"
-  - ORPC_TEST_VERSION=11.0"
+  - ORPC_TEST_VERSION="8.0"
+  - ORPC_TEST_VERSION="9.0"
+  - ORPC_TEST_VERSION="10.0"
+  - ORPC_TEST_VERSION="11.0"
+
+stages:
+  - name: test
+  - name: deploy
+    if: tag IS present
+
+jobs:
+  include:
+    - stage: deploy
+      script: echo "Deploy to PyPi"
+      deploy:
+        provider: pypi
+        user: OCA
+        password:
+          secure: "SY6C05pC8L34WESUeZTgi1B8isQox3IwFl1NX5fViDSYEGHLQNwbrzXIn9naUhbiJMIDn6zQuj5i6in7/GFcooWn764UzIMvY3ve2xKbIuGVIO6O8tdNm+zu6B582Ok7X7LzRPRRnmVn2NDEymmiZm/wKwRBXmIR2bIEEXdBEqXbqevsHCN2oVQZ+og68Gv0uj/W6oNyFCOZhB9ZB9sMqD12j40lSy5HKPdTb5n0ANdo3wnzCU6hU+Vpg91GXp6A5AXhxikeM9FMMnDR+tTleRFum86MvBl2Zke3mCrmCn2HQ7/kb8xWXk8rya8iKISFET+lD0XqbBnyqEVqjArMoxFXmAVEijonykdM2nm1ep6k/8bhrqej86S6bXktilv3AZ2B5apgUMqtRQDucfiSiZOvPqQXgpez3bgsAGlP/5A9VxLhSF1IdwZ/h5I3g4lMDb2E8H2IsXFtLmrLacVTDvWOkxga4AYtPwmX3IISZ1eQtE2iWdaz8ZC7Wf+S5ItS/i6ssjOvPRA+zA8+fkFOHJg9QvpYD9noZpfYbQZCm7qqcK/cO+0HwZp2VEQgnOYq4F5uwWCS7EYfvfNqGARRRxS3MEhsc9XuqS/lSFwgJvyp//VDykbQ2fTiQ4SQFtNWQmMxJNgNLMlGUOdymnlJW2IdIYk+2PSAfxr+S+XS2Pc="
+        distributions: "sdist bdist_wheel"
+        on:
+          repo: OCA/odoorpc
+          branch: master
+          tags: true
 
 before_install:
   - docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo --name db postgres:9.4
@@ -27,11 +47,3 @@ install:
 script:
   - python -m unittest discover -v
   - PYTHONPATH=.:$PYTHONPATH sphinx-build -b doctest -d doc/build/doctrees doc/source build/doctest
-
-deploy:
-  provider: pypi
-  user: OCA
-  password:
-    secure: SY6C05pC8L34WESUeZTgi1B8isQox3IwFl1NX5fViDSYEGHLQNwbrzXIn9naUhbiJMIDn6zQuj5i6in7/GFcooWn764UzIMvY3ve2xKbIuGVIO6O8tdNm+zu6B582Ok7X7LzRPRRnmVn2NDEymmiZm/wKwRBXmIR2bIEEXdBEqXbqevsHCN2oVQZ+og68Gv0uj/W6oNyFCOZhB9ZB9sMqD12j40lSy5HKPdTb5n0ANdo3wnzCU6hU+Vpg91GXp6A5AXhxikeM9FMMnDR+tTleRFum86MvBl2Zke3mCrmCn2HQ7/kb8xWXk8rya8iKISFET+lD0XqbBnyqEVqjArMoxFXmAVEijonykdM2nm1ep6k/8bhrqej86S6bXktilv3AZ2B5apgUMqtRQDucfiSiZOvPqQXgpez3bgsAGlP/5A9VxLhSF1IdwZ/h5I3g4lMDb2E8H2IsXFtLmrLacVTDvWOkxga4AYtPwmX3IISZ1eQtE2iWdaz8ZC7Wf+S5ItS/i6ssjOvPRA+zA8+fkFOHJg9QvpYD9noZpfYbQZCm7qqcK/cO+0HwZp2VEQgnOYq4F5uwWCS7EYfvfNqGARRRxS3MEhsc9XuqS/lSFwgJvyp//VDykbQ2fTiQ4SQFtNWQmMxJNgNLMlGUOdymnlJW2IdIYk+2PSAfxr+S+XS2Pc=
-  on:
-    tags: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 import os
-from distutils.core import setup
+import setuptools
 
 name = 'OdooRPC'
 version = '0.6.2'
 description = ("OdooRPC is a Python package providing an easy way to "
                "pilot your Odoo servers through RPC.")
+with open("README.rst", "r") as readme:
+    long_description = readme.read()
 keywords = ("openerp odoo server rpc client xml-rpc xmlrpc jsonrpc json-rpc "
             "odoorpc oerplib communication lib library python "
             "service web webservice")
-author = "ABF Osiell - Sebastien Alix"
-author_email = 'sebastien.alix@osiell.com'
-url = 'http://pythonhosted.org/OdooRPC/'
-download_url = 'http://pypi.python.org/packages/source/O/OdoORPC/OdooRPC-%s.tar.gz' % version
+author = "Sebastien Alix"
+author_email = 'seb@usr-src.org'
+url = 'https://github.com/OCA/odoorpc'
 license = 'LGPL v3'
 doc_build_dir = 'doc/build'
 doc_source_dir = 'doc/source'
@@ -39,15 +40,15 @@ except Exception:
     print("No Sphinx module found. You have to install Sphinx "
           "to be able to generate the documentation.")
 
-setup(name=name,
+setuptools.setup(name=name,
       version=version,
       description=description,
-      long_description=open('README.rst').read(),
+      long_description=long_description,
+      long_description_content_type="text/x-rst",
       keywords=keywords,
       author=author,
       author_email=author_email,
       url=url,
-      download_url=download_url,
       packages=['odoorpc',
                 'odoorpc.rpc'],
       license=license,


### PR DESCRIPTION
Travis is unable to upload a new release to PyPI: https://travis-ci.org/OCA/odoorpc/jobs/421480647#L1082

The problem was surely the use of `distutils` instead of `setuptools`.

TestPyPI link: https://test.pypi.org/project/OdooRPC/

Regarding Travis, I'm not sure how multiple jobs are dealing with the deploy/upload part. The first which finishes upload the package and the others simply fail or exit without any error?
@sbidoul maybe you know how it works?
I was reading about conditional release https://docs.travis-ci.com/user/deployment#conditional-releases-with-on and also check how you were dealing with this in https://github.com/acsone/click-odoo/blob/master/.travis.yml