### PR TITLE
FIX: Do not create a fake 'name' field on proxy models

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ Unreleased
        and isort + reformat the whole code base
 - FIX: int, float, etc type conversion might raise TypeError, catch em all
 - FIX: odoorpc.db.drop: remove existing user session to avoid HTTP session error
+- FIX: Do not create a fake 'name' field on proxy models (common 'display_name'
+       field handles already that case)
 
 0.7.0
 =====

--- a/odoorpc/env.py
+++ b/odoorpc/env.py
@@ -319,11 +319,4 @@ class Environment(object):
                 Field = fields.generate_field(field_name, field_data)
                 attrs['_columns'][field_name] = Field
                 attrs[field_name] = Field
-        # Case where no field 'name' exists, we generate one (which will be
-        # in readonly mode) in purpose to be filled with the 'name_get' method
-        if 'name' not in attrs['_columns']:
-            field_data = {'type': 'text', 'string': 'Name', 'readonly': True}
-            Field = fields.generate_field('name', field_data)
-            attrs['_columns']['name'] = Field
-            attrs['name'] = Field
         return type(cls_name, (Model,), attrs)

--- a/odoorpc/tests/test_model.py
+++ b/odoorpc/tests/test_model.py
@@ -140,3 +140,11 @@ class TestModel(LoginTestCase):
         product_fr.name = new_name_fr
         product_fr = product_fr.with_context()  # Refresh the recordset
         self.assertEqual(product_fr.name, new_name_fr)
+
+    def test_record_display_name(self):
+        p_id = self.partner_obj.search([])[:1][0]
+        partner = self.partner_obj.browse(p_id)
+        try:
+            partner.display_name
+        except Exception as exc:
+            self.fail(exc)


### PR DESCRIPTION
This was required for old Odoo/OpenERP, but starting with Odoo 8.0 the standard `display_name` field is here to handles that case (and is created by OdooRPC like any other field).

Fix #51