### PR TITLE
[IMP] add User-Agent for correct https connection to remote host

### DIFF
--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -110,6 +110,7 @@ class ProxyJSON(Proxy):
         data_json = json.dumps(data)
         request = Request(url=full_url, data=encode_data(data_json))
         request.add_header('Content-Type', 'application/json')
+        request.add_header('User-Agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7')
         response = self._opener.open(request, timeout=self._timeout)
         if not self._deserialize:
             return response


### PR DESCRIPTION
Bug:
trying to connect to remote host:
odoo = odoorpc.ODOO(host='xxx.com', port=443, protocol='jsonrpc+ssl')
raised error: urllib.error.HTTPError: HTTP Error 403: Forbidden

fix based on https://stackoverflow.com/questions/13303449/urllib2-httperror-http-error-403-forbidden