### PR TITLE
Pass context to other models when fetching more data

### DIFF
--- a/odoorpc/env.py
+++ b/odoorpc/env.py
@@ -316,6 +316,7 @@ class Environment(object):
         fields_get = self._odoo.execute(model, 'fields_get')
         for field_name, field_data in fields_get.items():
             if field_name not in FIELDS_RESERVED:
+                field_data['context'] = self._context # pass context to new fields ...
                 Field = fields.generate_field(field_name, field_data)
                 attrs['_columns'][field_name] = Field
                 attrs[field_name] = Field


### PR DESCRIPTION
When OdooRPC dynamically fetches more information (i.e. when accessing <instance>.partner_id.name), if the instance has been instantiated using `with_context`, this context is not passed along and can lead to unwanted results (i.e when using with_context(allowed_company_ids=[1,2,3]))

This fix allows to pass such context information.