### PR TITLE
[IMP] allow context manager

### DIFF
--- a/odoorpc/odoo.py
+++ b/odoorpc/odoo.py
@@ -379,6 +379,8 @@ class ODOO(object):
         self._password = None
         return True
 
+    close = logout  # Compatibility with contextlib.closing
+
     # ------------------------- #
     # -- Raw XML-RPC methods -- #
     # ------------------------- #

--- a/odoorpc/tests/test_login.py
+++ b/odoorpc/tests/test_login.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from contextlib import closing
+
 import odoorpc
+from odoorpc.error import InternalError
 from odoorpc.models import Model
 from odoorpc.tests import BaseTestCase
 
@@ -55,3 +58,15 @@ class TestLogin(BaseTestCase):
         )
         success = odoo.logout()
         self.assertFalse(success)
+
+    def test_logout_closing(self):
+        odoo = odoorpc.ODOO(
+            self.env['host'],
+            protocol=self.env['protocol'],
+            port=self.env['port'],
+            version=self.env['version'],
+        )
+        odoo.login(self.env['db'], self.env['user'], self.env['pwd'])
+        with closing(odoo):
+            odoo._check_logged_user()
+        self.assertRaises(InternalError, odoo._check_logged_user)


### PR DESCRIPTION
The simplest possible way to implement an automatic logout with a context manager is to rely on [`contextlib.closing`][1]. The only requirement is to have a `close` function. In this case, just an alias for `logout`.

With this patch, we're able now to wrap the logged-in odoo instance with that function and get automatic logout.

See the provided test for usage example.

[1]: https://docs.python.org/3.8/library/contextlib.html#contextlib.closing