### PR TITLE
basic implementation of handling HTTP basic-auth

### DIFF
--- a/odoorpc/odoo.py
+++ b/odoorpc/odoo.py
@@ -91,12 +91,9 @@ class ODOO(object):
         self._password = None
         self._db = DB(self)
         self._report = Report(self)
-        if basic_auth and len(basic_auth) == 3:
-            # print("using basic auth with:")
-            # print(basic_auth[0], basic_auth[1], basic_auth[2])
-            self._basic_auth = basic_auth
-        else:
-            self._basic_auth = None
+        self._basic_auth = basic_auth
+        if self._basic_auth and len(self._basic_auth) != 3:
+            raise ValueError("basic_auth needs to be tuple with localhost, user, pw")
         # Instanciate the server connector
         try:
             self._connector = rpc.PROTOCOLS[protocol](

--- a/odoorpc/odoo.py
+++ b/odoorpc/odoo.py
@@ -65,6 +65,7 @@ class ODOO(object):
         timeout=120,
         version=None,
         opener=None,
+        basic_auth=None,
     ):
         if protocol not in ['jsonrpc', 'jsonrpc+ssl']:
             txt = (
@@ -90,10 +91,16 @@ class ODOO(object):
         self._password = None
         self._db = DB(self)
         self._report = Report(self)
+        if basic_auth and len(basic_auth) == 3:
+            # print("using basic auth with:")
+            # print(basic_auth[0], basic_auth[1], basic_auth[2])
+            self._basic_auth = basic_auth
+        else:
+            self._basic_auth = None
         # Instanciate the server connector
         try:
             self._connector = rpc.PROTOCOLS[protocol](
-                self._host, self._port, timeout, version, opener=opener
+                self._host, self._port, self._basic_auth, timeout, version, opener=opener
             )
         except rpc.error.ConnectorError as exc:
             raise error.InternalError(exc.message)

--- a/odoorpc/rpc/__init__.py
+++ b/odoorpc/rpc/__init__.py
@@ -195,6 +195,7 @@ class ConnectorJSONRPC(Connector):
         self,
         host,
         port=8069,
+        basic_auth=None,
         timeout=120,
         version=None,
         deserialize=True,
@@ -208,9 +209,9 @@ class ConnectorJSONRPC(Connector):
             cookie_jar = CookieJar()
             opener = build_opener(HTTPCookieProcessor(cookie_jar))
         self._opener = opener
-        self._proxy_json, self._proxy_http = self._get_proxies()
+        self._proxy_json, self._proxy_http = self._get_proxies(basic_auth)
 
-    def _get_proxies(self):
+    def _get_proxies(self, basic_auth):
         """Returns the :class:`ProxyJSON <odoorpc.rpc.jsonrpclib.ProxyJSON>`
         and :class:`ProxyHTTP <odoorpc.rpc.jsonrpclib.ProxyHTTP>` instances
         corresponding to the server version used.
@@ -218,6 +219,7 @@ class ConnectorJSONRPC(Connector):
         proxy_json = jsonrpclib.ProxyJSON(
             self.host,
             self.port,
+            basic_auth,
             self._timeout,
             ssl=self.ssl,
             deserialize=self.deserialize,
@@ -226,6 +228,7 @@ class ConnectorJSONRPC(Connector):
         proxy_http = jsonrpclib.ProxyHTTP(
             self.host,
             self.port,
+            basic_auth,
             self._timeout,
             ssl=self.ssl,
             opener=self._opener,

--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -8,6 +8,9 @@ import logging
 import random
 import sys
 
+import urllib.request
+from urllib.request import HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler
+
 # Python 2
 if sys.version_info[0] < 3:
     from cookielib import CookieJar
@@ -61,16 +64,22 @@ def get_json_log_data(data):
 class Proxy(object):
     """Base class to implement a proxy to perform requests."""
 
-    def __init__(self, host, port, timeout=120, ssl=False, opener=None):
+    def __init__(self, host, port, basic_auth, timeout=120, ssl=False, opener=None):
         self._root_url = "{http}{host}:{port}".format(
             http=(ssl and "https://" or "http://"), host=host, port=port
         )
+        self._basic_auth = basic_auth
         self._timeout = timeout
         self._builder = URLBuilder(self)
         self._opener = opener
         if not opener:
             cookie_jar = CookieJar()
             self._opener = build_opener(HTTPCookieProcessor(cookie_jar))
+        if self._basic_auth:
+            passman = HTTPPasswordMgrWithDefaultRealm()
+            passman.add_password(None, self._basic_auth[0], self._basic_auth[1], self._basic_auth[2])
+            self._opener.add_handler(HTTPBasicAuthHandler(passman))
+            # print("opener added basicauth handler for ", self._basic_auth[0], self._basic_auth[1], self._basic_auth[2])
 
     def __getattr__(self, name):
         return getattr(self._builder, name)
@@ -88,9 +97,9 @@ class ProxyJSON(Proxy):
     """
 
     def __init__(
-        self, host, port, timeout=120, ssl=False, opener=None, deserialize=True
+        self, host, port, basic_auth, timeout=120, ssl=False, opener=None, deserialize=True
     ):
-        Proxy.__init__(self, host, port, timeout, ssl, opener)
+        Proxy.__init__(self, host, port, basic_auth, timeout, ssl, opener)
         self._deserialize = deserialize
 
     def __call__(self, url, params=None):

--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -64,7 +64,7 @@ def get_json_log_data(data):
 class Proxy(object):
     """Base class to implement a proxy to perform requests."""
 
-    def __init__(self, host, port, basic_auth, timeout=120, ssl=False, opener=None):
+    def __init__(self, host, port, basic_auth=None, timeout=120, ssl=False, opener=None):
         self._root_url = "{http}{host}:{port}".format(
             http=(ssl and "https://" or "http://"), host=host, port=port
         )
@@ -79,7 +79,6 @@ class Proxy(object):
             passman = HTTPPasswordMgrWithDefaultRealm()
             passman.add_password(None, self._basic_auth[0], self._basic_auth[1], self._basic_auth[2])
             self._opener.add_handler(HTTPBasicAuthHandler(passman))
-            # print("opener added basicauth handler for ", self._basic_auth[0], self._basic_auth[1], self._basic_auth[2])
 
     def __getattr__(self, name):
         return getattr(self._builder, name)


### PR DESCRIPTION
This implements a very basic handling of HTTP basic authentication

For this to work, the proxy will add a HTTPBasicAuthHandler with a HTTPPasswordMgrWithDefaultRealm to its opener. Whenever a server returns a 401 "Unauthorized", now urllib2 will automatically present supplied HTTP basic auth credentials.

The only thing users have to change in their code, in order to use basic authentication, is adding a parameter basic_auth=(url, user, pw) to their instantiation of odoorpc.