### PR TITLE
fix(exportable): v17 fields are sometimes non exportable

### DIFF
--- a/odoorpc/env.py
+++ b/odoorpc/env.py
@@ -322,6 +322,8 @@ class Environment(object):
         fields_get = self._odoo.execute(model, 'fields_get')
         for field_name, field_data in fields_get.items():
             if field_name not in FIELDS_RESERVED:
+                if 'exportable' in field_data and not field_data['exportable']:
+                    continue
                 Field = fields.generate_field(field_name, field_data)
                 attrs['_columns'][field_name] = Field
                 attrs[field_name] = Field


### PR DESCRIPTION
We are upgrading to Odoo 17 and saw a regression.
Some fields are specifically marked as exportable=False in the Odoo codebase.
This patch allow to check for the existence of this parameter and simply skip unnecessary fields.