### PR TITLE
Hide password when used with jsonrpc

### DIFF
--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -49,12 +49,16 @@ def get_json_log_data(data):
     """Returns a new `data` dictionary with hidden params
     for log purpose.
     """
-    log_data = data
+    log_data = copy.deepcopy(data)
     for param in LOG_HIDDEN_JSON_PARAMS:
         if param in data['params']:
-            if log_data is data:
-                log_data = copy.deepcopy(data)
             log_data['params'][param] = "**********"
+
+    # The password is the 3rd element of the args array.
+    if 'args' in data['params']:
+        if 2 in data['params']['args']:
+            log_data['params']['args'][2] = "**********"
+
     return log_data
 
 

--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -96,6 +96,7 @@ class ProxyJSON(Proxy):
     ):
         Proxy.__init__(self, host, port, timeout, ssl, opener)
         self._deserialize = deserialize
+        self.debug = logger.isEnabledFor(logging.DEBUG)
 
     def __call__(self, url, params=None):
         if params is None:
@@ -109,8 +110,12 @@ class ProxyJSON(Proxy):
         if url.startswith('/'):
             url = url[1:]
         full_url = self._get_full_url(url)
-        log_data = get_json_log_data(data)
-        logger.debug(LOG_JSON_SEND_MSG, {'url': full_url, 'data': log_data})
+
+        log_data = None
+        if self.debug:
+            log_data = get_json_log_data(data)
+            logger.debug(LOG_JSON_SEND_MSG, {'url': full_url, 'data': log_data})
+
         data_json = json.dumps(data)
         request = Request(url=full_url, data=encode_data(data_json))
         request.add_header('Content-Type', 'application/json')


### PR DESCRIPTION
If debugging is enabled, the password used to authenticate jsonrpc calls is logged.

This PR also fixes deepcopy being called on every jsonrpc call.

Fixes #70.