### PR TITLE
[IMP] Hide sensitive or bloated data in logs

### DIFF
--- a/odoorpc/db.py
+++ b/odoorpc/db.py
@@ -8,6 +8,7 @@ import sys
 
 from odoorpc import error
 from odoorpc.tools import v
+from odoorpc.rpc.jsonrpclib import Secret, Bloat
 
 # Python 2
 if sys.version_info[0] < 3:
@@ -110,7 +111,7 @@ class DB(object):
         :raise: :class:`odoorpc.error.RPCError` (access denied / wrong database)
         :raise: `urllib.error.URLError` (connection error)
         """
-        args = [password, db]
+        args = [Secret(password), db]
         if v(self._odoo.version)[0] >= 9:
             args.append(format_)
         data = self._odoo.json(
@@ -150,7 +151,7 @@ class DB(object):
             {
                 "service": "db",
                 "method": "change_admin_password",
-                "args": [password, new_password],
+                "args": [Secret(password), Secret(new_password)],
             },
         )
 
@@ -188,7 +189,7 @@ class DB(object):
             {
                 "service": "db",
                 "method": "create_database",
-                "args": [password, db, demo, lang, admin_password],
+                "args": [Secret(password), db, demo, lang, Secret(admin_password)],
             },
         )
 
@@ -218,7 +219,7 @@ class DB(object):
             self._odoo.logout()
         data = self._odoo.json(
             "/jsonrpc",
-            {"service": "db", "method": "drop", "args": [password, db]},
+            {"service": "db", "method": "drop", "args": [Secret(password), db]},
         )
         return data["result"]
 
@@ -244,7 +245,7 @@ class DB(object):
         :raise: :class:`odoorpc.error.RPCError` (access denied / wrong database)
         :raise: `urllib.error.URLError` (connection error)
         """
-        args = [password, db, new_db]
+        args = [Secret(password), db, new_db]
         # neutralize_database parameter is only available from Odoo 16+
         if neutralize_database and v(self._odoo.version)[0] >= 16:
             args.append(neutralize_database)
@@ -318,6 +319,6 @@ class DB(object):
             {
                 "service": "db",
                 "method": "restore",
-                "args": [password, db, b64_data, copy],
+                "args": [Secret(password), db, Bloat(b64_data), copy],
             },
         )

--- a/odoorpc/odoo.py
+++ b/odoorpc/odoo.py
@@ -8,6 +8,7 @@ from odoorpc import error, rpc, session, tools
 from odoorpc.db import DB
 from odoorpc.env import Environment
 from odoorpc.report import Report
+from odoorpc.rpc.jsonrpclib import Secret
 
 
 class ODOO(object):
@@ -337,6 +338,7 @@ class ODOO(object):
         :raise: :class:`odoorpc.error.RPCError`
         :raise: `urllib.error.URLError` (connection error)
         """
+        password = Secret(password)
         # Get the user's ID and generate the corresponding user record
         if tools.v(self.version)[0] >= 10:
             data = self.json(

--- a/odoorpc/rpc/jsonrpclib.py
+++ b/odoorpc/rpc/jsonrpclib.py
@@ -19,6 +19,16 @@ if sys.version_info[0] < 3:
     def decode_data(data):
         return data
 
+    class Secret(unicode):  # noqa: F821
+        """Used to hide sensitive string RPC parameters in logs."""
+
+        MASK = "**********"
+
+    class Bloat(unicode):  # noqa: F821
+        """Used to replace bloated string RPC parameters in logs."""
+
+        MASK = "<...>"
+
 
 # Python >= 3
 else:
@@ -35,8 +45,17 @@ else:
     def decode_data(data):
         return io.StringIO(data.read().decode("utf-8"))
 
+    class Secret(str):
+        """Used to hide sensitive string RPC parameters in logs."""
 
-LOG_HIDDEN_JSON_PARAMS = ["password"]
+        MASK = "**********"
+
+    class Bloat(str):
+        """Used to replace bloated string RPC parameters in logs."""
+
+        MASK = "<...>"
+
+
 LOG_JSON_SEND_MSG = "(JSON,send) %(url)s %(data)s"
 LOG_JSON_RECV_MSG = "(JSON,recv) %(url)s %(data)s => %(result)s"
 LOG_HTTP_SEND_MSG = "(HTTP,send) %(url)s%(data)s"
@@ -45,16 +64,32 @@ LOG_HTTP_RECV_MSG = "(HTTP,recv) %(url)s%(data)s => %(result)s"
 logger = logging.getLogger(__name__)
 
 
+def _hide_parameters(data):
+    """Recursively hide Secret and Bloat values in `data`."""
+    if isinstance(data, dict):
+        for key in data:
+            value = data[key]
+            data[key] = _hide_parameters(value)
+    elif isinstance(data, list):
+        for e in data:
+            data[data.index(e)] = _hide_parameters(e)
+    elif isinstance(data, tuple):
+        # Replace tuple by list (mutable)
+        new_data = []
+        for e in data:
+            new_data.append(_hide_parameters(e))
+        return tuple(new_data)
+    elif isinstance(data, Secret):
+        return Secret.MASK
+    elif isinstance(data, Bloat):
+        return Bloat.MASK
+    return data
+
+
 def get_json_log_data(data):
-    """Returns a new `data` dictionary with hidden params
-    for log purpose.
-    """
-    log_data = data
-    for param in LOG_HIDDEN_JSON_PARAMS:
-        if param in data["params"]:
-            if log_data is data:
-                log_data = copy.deepcopy(data)
-            log_data["params"][param] = "**********"
+    """Returns a new `data` dictionary with hidden params for log purpose."""
+    log_data = copy.deepcopy(data)
+    _hide_parameters(log_data)
     return log_data
 
 

--- a/odoorpc/tests/test_logging.py
+++ b/odoorpc/tests/test_logging.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import base64
+import logging
+import os
+
+from odoorpc.tests import LoginTestCase
+from odoorpc.rpc.jsonrpclib import Secret, Bloat
+
+
+class TestLogging(LoginTestCase):
+    @classmethod
+    def setUpClass(cls):
+        LoginTestCase.setUpClass()
+        dummy_file = os.urandom(1024)
+        b64_data = str(base64.b64encode(dummy_file))
+        cls.attachment_values = {"name": "TEST", "datas": Bloat(b64_data)}
+
+    def test_hidden_parameters_in_logs(self):
+        # Expected log output:
+        # DEBUG:odoorpc.rpc.jsonrpclib:(JSON,send) http://localhost:8069/jsonrpc {'jsonrpc': '2.0', 'method': 'call', 'params': {'service': 'object', 'method': 'execute_kw', 'args': ['odoorpc_test', 2, '**********', 'ir.attachment', 'create', ({'name': 'TEST', 'datas': '<...>'},), {'context': {'lang': 'en_US', 'tz': 'Europe/Brussels', 'uid': 2}}]}, 'id': 156322240}
+        logger = logging.getLogger("odoorpc")
+        logger.setLevel(logging.DEBUG)
+        with self.assertLogs("odoorpc", level="DEBUG") as logs:
+            self.odoo.env["ir.attachment"].create(self.attachment_values)
+            # Password and b64 value should be hidden in logs
+            hidden_password = (
+                f"'{self.odoo.env.db}', {self.odoo.env.uid}, '{Secret.MASK}', "
+                "'ir.attachment', 'create'"
+            )
+            self.assertTrue(any(hidden_password in log for log in logs.output))
+            self.assertFalse(any(self.odoo._password in log for log in logs.output))
+            hidden_bloat = f"'datas': '{Bloat.MASK}'"
+            self.assertTrue(any(hidden_bloat in log for log in logs.output))
+            self.assertFalse(
+                any(self.attachment_values["datas"] in log for log in logs.output)
+            )


### PR DESCRIPTION
Supersedes #103 and fix #70.

Two new classes are provided acting as replacement for string values:
- `odoorpc.rpc.jsonrpclib.Secret`
- `odoorpc.rpc.jsonrpclib.Bloat`

When such objects are detected in the data sent by RPC, they are replaced by their `.MASK` value.

While used internally by OdooRPC to hide password and bloated data, these classes can also be used by the user to hide any sensitive data in its own payloads.

NOTE: I'm not able to test this with Python 2, but I should drop such support anyway (the CI isn't running it for quite some time now).