### PR TITLE
[ADD] .readthedocs.yaml: publish doc on readthedocs.org

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Address #97 

Documentation is not auto-generated for some years now. This file should fix that.